### PR TITLE
renamed `partial` to `include` in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ grunt.initConfig({
 With the helper registered, you may now begin using it in your templates:
 
 ```html
-{{partial 'foo'}}
+{{include 'foo'}}
 ```
 
 Optionally pass in a context as the second parameter:
 
 ```html
-{{partial 'foo' bar}}
+{{include 'foo' bar}}
 ```
 
 #### Wildcard patterns
@@ -60,7 +60,7 @@ Optionally pass in a context as the second parameter:
 Globbing patterns may also be used:
 
 ```html
-{{partial 'chapter-*' bar}}
+{{include 'chapter-*' bar}}
 ```
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,13 +1,13 @@
 With the helper registered, you may now begin using it in your templates:
 
 ```html
-{{partial 'foo'}}
+{{include 'foo'}}
 ```
 
 Optionally pass in a context as the second parameter:
 
 ```html
-{{partial 'foo' bar}}
+{{include 'foo' bar}}
 ```
 
 ### Wildcard patterns
@@ -15,5 +15,5 @@ Optionally pass in a context as the second parameter:
 Globbing patterns may also be used:
 
 ```html
-{{partial 'chapter-*' bar}}
+{{include 'chapter-*' bar}}
 ```

--- a/index.js
+++ b/index.js
@@ -21,13 +21,13 @@ module.exports.register = function (Handlebars, options, params) {
   var opts = options || {};
 
   /**
-   * {{partial}}
+   * {{include}}
    * Alternative to {{> partial }}
    *
    * @param  {String} name    The name of the partial to use
    * @param  {Object} context The context to pass to the partial
    * @return {String}         Returns compiled HTML
-   * @xample: {{partial 'foo' bar}}
+   * @xample: {{include 'foo' bar}}
    */
   Handlebars.registerHelper('include', function(name, context) {
 
@@ -83,6 +83,6 @@ module.exports.register = function (Handlebars, options, params) {
       return output;
     }).join('\n');
 
-    return new Handlebars.SafeString(partials);
+    return new Handlebars.SafeString(output);
   });
 };


### PR DESCRIPTION
also renamed return statement from `partial` to `output`. 

``` js
return new Handlebars.SafeString(partials);
return new Handlebars.SafeString(output);
```

wasn't sure if this is what you meant. 
