### PR TITLE
consider using grunt.verbose.write rather than console.log

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports.register = function (Handlebars, options, params) {
       // `opts`              = Custom properties defined in Assemble options
       // `grunt.config.data` = Data from grunt.config.data
       //                       (e.g. pkg: grunt.file.readJSON('package.json'))
-      console.log(metadata);
+      grunt.verbose.write(metadata);
       var ctx = _.extend({}, grunt.config.data, opts, this, opts.data[name], metadata, context);
       ctx = grunt.config.process(ctx);
 


### PR DESCRIPTION
the metadata is polluting the default grunt output, so this really should be tucked into verbose
